### PR TITLE
MCP GW 0.2.0

### DIFF
--- a/charts/mcp-gateway/Chart.yaml
+++ b/charts/mcp-gateway/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: mcp-gateway
 description: A Helm chart for frontegg's MCP Gateway (mcp-auth + mcp-gw)
 type: application
-version: 0.1.0
+version: 0.2.0

--- a/charts/mcp-gateway/templates/NOTES.txt
+++ b/charts/mcp-gateway/templates/NOTES.txt
@@ -2,11 +2,11 @@ MCP Gateway has been deployed with the following services:
 
 1. MCP Auth Service:
    Service: {{ include "fullname" . }}-auth
-   Port: 8080
+   Port: {{ .Values.mcpAuth.port }}
 
 2. MCP Gateway Service:
    Service: {{ include "fullname" . }}-gw
-   Port: 8080
+   Port: {{ .Values.mcpGw.port }}
 
 To access the services:
 {{- if contains "NodePort" .Values.service.type }}
@@ -26,8 +26,19 @@ To access the services:
   kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "fullname" . }}-gw
 {{- else if contains "ClusterIP" .Values.service.type }}
   # Port forward MCP Auth
-  kubectl --namespace {{ .Release.Namespace }} port-forward svc/{{ include "fullname" . }}-auth 8080:8080
+  kubectl --namespace {{ .Release.Namespace }} port-forward svc/{{ include "fullname" . }}-auth 8080:{{ .Values.mcpAuth.port }}
 
   # Port forward MCP Gateway (in another terminal)
-  kubectl --namespace {{ .Release.Namespace }} port-forward svc/{{ include "fullname" . }}-gw 8081:8080
+  kubectl --namespace {{ .Release.Namespace }} port-forward svc/{{ include "fullname" . }}-gw 8081:{{ .Values.mcpGw.port }}
 {{- end }}
+
+Routing Configuration:
+  The following paths should be routed to the appropriate service:
+
+  {{ include "fullname" . }}-auth (port {{ .Values.mcpAuth.port }}):
+    - /.well-known/*
+    - /authorize
+    - /integration-callback
+
+  {{ include "fullname" . }}-gw (port {{ .Values.mcpGw.port }}):
+    - / (all other paths)

--- a/charts/mcp-gateway/values.yaml
+++ b/charts/mcp-gateway/values.yaml
@@ -5,7 +5,7 @@
 # MCP Auth container/deployment configuration
 mcpAuth:
   repository: 527305576865.dkr.ecr.us-east-1.amazonaws.com/docker-hub/frontegg/hybrid-agent-link-auth
-  tag: latest
+  tag: 2026.2.14.075916
   pullPolicy: IfNotPresent
   replicaCount: 1
   port: 8080
@@ -38,7 +38,7 @@ mcpAuth:
 # MCP Gateway container/deployment configuration
 mcpGw:
   repository: 527305576865.dkr.ecr.us-east-1.amazonaws.com/docker-hub/frontegg/hybrid-agent-link-gw
-  tag: latest
+  tag: 2026.2.14.075916
   pullPolicy: IfNotPresent
   replicaCount: 1
   port: 8080
@@ -128,6 +128,8 @@ affinity: {}
 
 env:
   redisHost: ""
+  redisPassword: ""
+  redisDb: "0"
   redisTlsEnabled: "true"
   cacheTtl: "300"
   fronteggRegion: "eu"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Helm chart-only changes (defaults and operator guidance); main risk is deployments unexpectedly moving off `latest` to a pinned image tag and new Redis defaults affecting existing overrides.
> 
> **Overview**
> Bumps the `mcp-gateway` Helm chart version to `0.2.0` and pins default `mcpAuth`/`mcpGw` image tags from `latest` to `2026.2.14.075916`.
> 
> Improves chart `NOTES.txt` to use configurable ports in examples and adds a brief routing cheat-sheet for directing auth-related paths to `-auth` and everything else to `-gw`. Also extends `values.yaml` with Redis configuration defaults (`env.redisPassword`, `env.redisDb`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9e84b55f7a08d882f127c8d6aab175039d61f65e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->