### PR TITLE
MCP GW 0.3.0

### DIFF
--- a/charts/mcp-gateway/Chart.yaml
+++ b/charts/mcp-gateway/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: mcp-gateway
 description: A Helm chart for frontegg's MCP Gateway (mcp-auth + mcp-gw)
 type: application
-version: 0.2.0
+version: 0.3.0

--- a/charts/mcp-gateway/values.yaml
+++ b/charts/mcp-gateway/values.yaml
@@ -5,7 +5,7 @@
 # MCP Auth container/deployment configuration
 mcpAuth:
   repository: 527305576865.dkr.ecr.us-east-1.amazonaws.com/docker-hub/frontegg/hybrid-agen-co-auth
-  tag: 91ef8d3
+  tag: f49b4bc
   pullPolicy: IfNotPresent
   replicaCount: 1
   port: 8080
@@ -38,7 +38,7 @@ mcpAuth:
 # MCP Gateway container/deployment configuration
 mcpGw:
   repository: 527305576865.dkr.ecr.us-east-1.amazonaws.com/docker-hub/frontegg/hybrid-agen-co-gw
-  tag: 91ef8d3
+  tag: f49b4bc
   pullPolicy: IfNotPresent
   replicaCount: 1
   port: 8080

--- a/charts/mcp-gateway/values.yaml
+++ b/charts/mcp-gateway/values.yaml
@@ -4,8 +4,8 @@
 
 # MCP Auth container/deployment configuration
 mcpAuth:
-  repository: 527305576865.dkr.ecr.us-east-1.amazonaws.com/docker-hub/frontegg/hybrid-agent-link-auth
-  tag: 2026.2.14.075916
+  repository: 527305576865.dkr.ecr.us-east-1.amazonaws.com/docker-hub/frontegg/hybrid-agen-co-auth
+  tag: 91ef8d3
   pullPolicy: IfNotPresent
   replicaCount: 1
   port: 8080
@@ -37,8 +37,8 @@ mcpAuth:
 
 # MCP Gateway container/deployment configuration
 mcpGw:
-  repository: 527305576865.dkr.ecr.us-east-1.amazonaws.com/docker-hub/frontegg/hybrid-agent-link-gw
-  tag: 2026.2.14.075916
+  repository: 527305576865.dkr.ecr.us-east-1.amazonaws.com/docker-hub/frontegg/hybrid-agen-co-gw
+  tag: 91ef8d3
   pullPolicy: IfNotPresent
   replicaCount: 1
   port: 8080
@@ -128,6 +128,7 @@ affinity: {}
 
 env:
   redisHost: ""
+  redisPort: "6379"
   redisPassword: ""
   redisDb: "0"
   redisTlsEnabled: "true"
@@ -138,7 +139,7 @@ env:
   applicationId: ""
   fronteggMcpGwHost: ""
   externalAuthorizationUrl: ""
-  integrationCallbackEndpoint: ""
+  hybridAuthHost: ""
   # approvalFlowWebhookEndpoint: ""
   # eventWebhookProvider: ""
   # eventWebhookUrl: ""


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the default container images/tags and introduces new env defaults, which can alter runtime behavior of deployed releases even without template changes.
> 
> **Overview**
> Bumps the `mcp-gateway` Helm chart version to `0.3.0` and updates the default `mcpAuth`/`mcpGw` image repositories and tags to new artifacts.
> 
> Extends the default `env` values by adding `redisPort` (default `6379`) and a new `hybridAuthHost` setting.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 58a6e0e2bc737630d797113430f7b9edf4150c1a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->