### PR TITLE
Bump mcp gw to 0.4.0

### DIFF
--- a/charts/mcp-gateway/Chart.yaml
+++ b/charts/mcp-gateway/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: mcp-gateway
 description: A Helm chart for frontegg's MCP Gateway (mcp-auth + mcp-gw)
 type: application
-version: 0.3.0
+version: 0.4.0

--- a/charts/mcp-gateway/values.yaml
+++ b/charts/mcp-gateway/values.yaml
@@ -5,7 +5,7 @@
 # MCP Auth container/deployment configuration
 mcpAuth:
   repository: 527305576865.dkr.ecr.us-east-1.amazonaws.com/docker-hub/frontegg/hybrid-agen-co-auth
-  tag: f49b4bc
+  tag: ea97211
   pullPolicy: IfNotPresent
   replicaCount: 1
   port: 8080
@@ -38,7 +38,7 @@ mcpAuth:
 # MCP Gateway container/deployment configuration
 mcpGw:
   repository: 527305576865.dkr.ecr.us-east-1.amazonaws.com/docker-hub/frontegg/hybrid-agen-co-gw
-  tag: f49b4bc
+  tag: ea97211
   pullPolicy: IfNotPresent
   replicaCount: 1
   port: 8080


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Deploys new `mcp-auth` and `mcp-gw` container images by updating the Helm chart version and image tags, which could introduce runtime behavior changes at rollout. Risk is limited to deployment configuration changes (no chart templating logic changes shown).
> 
> **Overview**
> Bumps the `mcp-gateway` Helm chart version from `0.3.0` to `0.4.0`.
> 
> Updates the default Docker image tags for both `mcpAuth` and `mcpGw` in `values.yaml` from `f49b4bc` to `ea97211`, causing deployments to roll forward to the newer images.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97e3dd9b9cf3a415f63c43e0f15bcbc93f976117. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->