### PR TITLE
Bump mcp gw to 0.6.0

### DIFF
--- a/charts/mcp-gateway/Chart.yaml
+++ b/charts/mcp-gateway/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: mcp-gateway
 description: A Helm chart for frontegg's MCP Gateway (mcp-auth + mcp-gw)
 type: application
-version: 0.5.0
+version: 0.6.0

--- a/charts/mcp-gateway/templates/NOTES.txt
+++ b/charts/mcp-gateway/templates/NOTES.txt
@@ -48,8 +48,8 @@ Routing Configuration:
     - /authorize                        (GET)
     - /dcr/register                     (POST)
     - /token                            (POST)
-    - /integration-callback            (GET)
-    - /integration-callback/implicit   (POST)
+    - /integration-callback             (GET)
+    - /integration-callback/implicit    (POST)
     - /external-mcp/authorize           (GET)
     - /external-mcp/callback            (GET)
 

--- a/charts/mcp-gateway/templates/NOTES.txt
+++ b/charts/mcp-gateway/templates/NOTES.txt
@@ -50,7 +50,6 @@ Routing Configuration:
     - /token                            (POST)
     - /integration-callback            (GET)
     - /integration-callback/implicit   (POST)
-    - /security-stepup-verify           (GET)
     - /external-mcp/authorize           (GET)
     - /external-mcp/callback            (GET)
 

--- a/charts/mcp-gateway/templates/NOTES.txt
+++ b/charts/mcp-gateway/templates/NOTES.txt
@@ -32,13 +32,36 @@ To access the services:
   kubectl --namespace {{ .Release.Namespace }} port-forward svc/{{ include "fullname" . }}-gw 8081:{{ .Values.mcpGw.port }}
 {{- end }}
 
+Health checks:
+  Both services expose GET /health on port {{ .Values.mcpGw.port }} and should return 200.
+    kubectl rollout status deploy/{{ include "fullname" . }}-auth --namespace {{ .Release.Namespace }}
+    kubectl rollout status deploy/{{ include "fullname" . }}-gw --namespace {{ .Release.Namespace }}
+
 Routing Configuration:
-  The following paths should be routed to the appropriate service:
+  This chart ships no Ingress/router. Front both services with your own ingress or
+  API gateway, preserving the Host header (must match env.fronteggMcpGwHost).
+  Route the auth paths below to -auth; send everything else to -gw. Declare the auth
+  paths BEFORE the catch-all "/" on order-based routers.
 
   {{ include "fullname" . }}-auth (port {{ .Values.mcpAuth.port }}):
-    - /.well-known/*
-    - /authorize
-    - /integration-callback
+    - /.well-known/*                    (GET)
+    - /authorize                        (GET)
+    - /dcr/register                     (POST)
+    - /token                            (POST)
+    - /integration-callback            (GET)
+    - /integration-callback/implicit   (POST)
+    - /security-stepup-verify           (GET)
+    - /external-mcp/authorize           (GET)
+    - /external-mcp/callback            (GET)
 
   {{ include "fullname" . }}-gw (port {{ .Values.mcpGw.port }}):
     - / (all other paths)
+{{- if eq (.Values.env.eventStdoutEnabled | default "") "true" }}
+
+Event delivery:
+  EVENT_STDOUT_ENABLED is on — events are written to each pod's stdout as
+  newline-delimited JSON tagged {"stream":"mcp-gw-events",...}. Point your log
+  collector (OTEL/Fluent Bit/Vector) at container stdout and filter on that stream.
+{{- end }}
+
+Docs: https://developers.frontegg.com/agen-for-saas/configuration/hosting-mcp-gateway

--- a/charts/mcp-gateway/values.yaml
+++ b/charts/mcp-gateway/values.yaml
@@ -5,7 +5,7 @@
 # MCP Auth container/deployment configuration
 mcpAuth:
   repository: 527305576865.dkr.ecr.us-east-1.amazonaws.com/docker-hub/frontegg/hybrid-agen-co-auth
-  tag: e130230
+  tag: 3c9f1ce
   pullPolicy: IfNotPresent
   replicaCount: 1
   port: 8080
@@ -38,7 +38,7 @@ mcpAuth:
 # MCP Gateway container/deployment configuration
 mcpGw:
   repository: 527305576865.dkr.ecr.us-east-1.amazonaws.com/docker-hub/frontegg/hybrid-agen-co-gw
-  tag: e130230
+  tag: 3c9f1ce
   pullPolicy: IfNotPresent
   replicaCount: 1
   port: 8080
@@ -141,6 +141,12 @@ env:
   externalAuthorizationUrl: ""
   hybridAuthHost: ""
   # approvalFlowWebhookEndpoint: ""
+  # Event delivery (choose one sink for non-raw events):
+  #  - webhook: set eventWebhookProvider/Url/Secret below
+  #  - stdout:  set eventStdoutEnabled "true" to emit newline-delimited JSON
+  #             events to stdout (tagged {"stream":"mcp-gw-events",...}) for a
+  #             log collector (OTEL/Fluent Bit/Vector) to scrape. No webhook needed.
+  # eventStdoutEnabled: "true"
   # eventWebhookProvider: ""
   # eventWebhookUrl: ""
   # eventWebhookSecret: ""

--- a/charts/mcp-gateway/values.yaml
+++ b/charts/mcp-gateway/values.yaml
@@ -141,11 +141,6 @@ env:
   externalAuthorizationUrl: ""
   hybridAuthHost: ""
   # approvalFlowWebhookEndpoint: ""
-  # Event delivery (choose one sink for non-raw events):
-  #  - webhook: set eventWebhookProvider/Url/Secret below
-  #  - stdout:  set eventStdoutEnabled "true" to emit newline-delimited JSON
-  #             events to stdout (tagged {"stream":"mcp-gw-events",...}) for a
-  #             log collector (OTEL/Fluent Bit/Vector) to scrape. No webhook needed.
   # eventStdoutEnabled: "true"
   # eventWebhookProvider: ""
   # eventWebhookUrl: ""


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Helm version/image tag bump and documentation-only values comment; no template or runtime config behavior changes beyond deploying new container images.
> 
> **Overview**
> **Releases mcp-gateway Helm chart 0.6.0** and pins **mcp-auth** and **mcp-gw** images from `e130230` to **`3c9f1ce`**.
> 
> Post-install **NOTES** are expanded for operators: rollout/`/health` checks, explicit guidance that the chart has no Ingress (Host must match `env.fronteggMcpGwHost`, auth paths before the `/` catch-all), a fuller **mcp-auth** path list with HTTP methods (DCR, token, integration callbacks, external MCP OAuth), optional **event stdout** instructions when `env.eventStdoutEnabled` is `"true"`, and a link to hosting docs. **`values.yaml`** adds a commented `# eventStdoutEnabled: "true"` example under `env`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fdf418e22ed5ba926f8e7bbd4041f10b668d4fcc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->