### PR TITLE
Bump mcp gw to 0.9.0

### DIFF
--- a/charts/mcp-gateway/Chart.yaml
+++ b/charts/mcp-gateway/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: mcp-gateway
 description: A Helm chart for frontegg's MCP Gateway (mcp-auth + mcp-gw)
 type: application
-version: 0.8.0
+version: 0.9.0

--- a/charts/mcp-gateway/values.yaml
+++ b/charts/mcp-gateway/values.yaml
@@ -5,7 +5,7 @@
 # MCP Auth container/deployment configuration
 mcpAuth:
   repository: 527305576865.dkr.ecr.us-east-1.amazonaws.com/docker-hub/frontegg/hybrid-agen-co-auth
-  tag: 72d0db7
+  tag: e566dca
   pullPolicy: IfNotPresent
   replicaCount: 1
   port: 8080
@@ -38,7 +38,7 @@ mcpAuth:
 # MCP Gateway container/deployment configuration
 mcpGw:
   repository: 527305576865.dkr.ecr.us-east-1.amazonaws.com/docker-hub/frontegg/hybrid-agen-co-gw
-  tag: 72d0db7
+  tag: e566dca
   pullPolicy: IfNotPresent
   replicaCount: 1
   port: 8080


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Helm version and image tag-only change with no chart template or runtime config changes beyond the new images.
> 
> **Overview**
> Releases **mcp-gateway** Helm chart **0.9.0** and pins both **mcp-auth** and **mcp-gw** container images to tag **`e566dca`** (from **`72d0db7`**). No template, resource, or probe changes—only chart version and default image tags in `values.yaml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9fb65e3bafbf059b64293b08f952bc84da0ca1bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->