### PR TITLE
Bump mcp gw to 0.10.0

### DIFF
--- a/charts/mcp-gateway/Chart.yaml
+++ b/charts/mcp-gateway/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: mcp-gateway
 description: A Helm chart for frontegg's MCP Gateway (mcp-auth + mcp-gw)
 type: application
-version: 0.9.0
+version: 0.10.0

--- a/charts/mcp-gateway/values.yaml
+++ b/charts/mcp-gateway/values.yaml
@@ -5,7 +5,7 @@
 # MCP Auth container/deployment configuration
 mcpAuth:
   repository: 527305576865.dkr.ecr.us-east-1.amazonaws.com/docker-hub/frontegg/hybrid-agen-co-auth
-  tag: e566dca
+  tag: 65e17bc
   pullPolicy: IfNotPresent
   replicaCount: 1
   port: 8080
@@ -38,7 +38,7 @@ mcpAuth:
 # MCP Gateway container/deployment configuration
 mcpGw:
   repository: 527305576865.dkr.ecr.us-east-1.amazonaws.com/docker-hub/frontegg/hybrid-agen-co-gw
-  tag: e566dca
+  tag: 65e17bc
   pullPolicy: IfNotPresent
   replicaCount: 1
   port: 8080


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Packaging-only version and image tag updates with no chart logic or configuration changes beyond defaults.
> 
> **Overview**
> Bumps the **mcp-gateway** Helm chart release from **0.9.0** to **0.10.0** and aligns default container images for **mcp-auth** and **mcp-gw** from tag `e566dca` to `65e17bc`. No template, resource, or env changes—only version metadata in `Chart.yaml` and image tags in `values.yaml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f02a6ba35f566ccaac2562d9d2d729fb1c786ac4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->