### PR TITLE
Bump mcp gw to 0.11.0

### DIFF
--- a/charts/mcp-gateway/Chart.yaml
+++ b/charts/mcp-gateway/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: mcp-gateway
 description: A Helm chart for frontegg's MCP Gateway (mcp-auth + mcp-gw)
 type: application
-version: 0.10.0
+version: 0.11.0

--- a/charts/mcp-gateway/README.md
+++ b/charts/mcp-gateway/README.md
@@ -50,6 +50,9 @@ env:
   hybridAuthHost: "https://auth.example.com"
 ```
 
+To keep secrets out of your values file, put them in a Secret you manage yourself and
+reference it with `existingSecret` — see [Configuration](#configuration).
+
 ## Routing
 
 Configure your ingress/API gateway with the path map below. Route the auth paths to
@@ -77,7 +80,19 @@ Router requirements:
 ## Configuration
 
 Keys under `env` are camelCase and converted to `UPPER_SNAKE_CASE` environment variables
-(e.g. `vendorClientId` → `VENDOR_CLIENT_ID`). Every key under `env` is injected into **both** deployments.
+(e.g. `vendorClientId` → `VENDOR_CLIENT_ID`). Every key under `env` is injected into
+**both** deployments, rendered inline as `value:` on the containers.
+
+For secrets, you have two options:
+
+- **Inline under `env`** — simplest; the value lives in your Helm values (and the Helm
+  release, stored in the cluster). Fine for quick start / dev.
+- **`existingSecret`** — name of a Secret you manage **outside** this chart (External
+  Secrets Operator, sealed-secrets, `kubectl create secret`, …). When set, it's loaded
+  into both deployments via `envFrom`, keeping secret material out of Helm entirely.
+  Its keys must already be `UPPER_SNAKE_CASE` env var names (e.g. `REDIS_PASSWORD`), and
+  the Secret must exist in the release namespace before the pods start. Recommended for
+  production. See [Referencing an existing Secret](#referencing-an-existing-secret).
 
 ### Required environment (`env`)
 
@@ -110,6 +125,36 @@ Keys under `env` are camelCase and converted to `UPPER_SNAKE_CASE` environment v
 
 To add any other env var, just add a key under `env`.
 
+### Referencing an existing Secret
+
+To keep sensitive values out of Helm, create a Secret whose keys are the final
+`UPPER_SNAKE_CASE` env var names and point `existingSecret` at it:
+
+```bash
+kubectl create secret generic my-mcp-secrets \
+  --from-literal=REDIS_PASSWORD='...' \
+  --from-literal=SECRET_ENCRYPTION_KEY='...'
+```
+
+```yaml
+existingSecret: "my-mcp-secrets"
+```
+
+The Secret is loaded into both deployments via `envFrom`:
+
+```yaml
+envFrom:
+  - secretRef:
+      name: my-mcp-secrets
+```
+
+The chart does not create or manage this Secret — it must exist in the release
+namespace before the pods start, or they fail with `CreateContainerConfigError`. Keys
+present in both `existingSecret` and `env` resolve to the `env` value (inline `value:`
+wins over `envFrom`). Changing the Secret does **not** restart the pods automatically —
+run `kubectl rollout restart deploy/<release>-mcp-gateway-auth deploy/<release>-mcp-gateway-gw`
+(or use a controller like Stakater Reloader).
+
 ### Event delivery
 
 Non-raw events are delivered to **one** sink:
@@ -135,15 +180,18 @@ Non-raw events are delivered to **one** sink:
 
 ### Integration secret encryption
 
-For hybrid (on-prem) deployments, the Frontegg control plane can deliver integration
-secrets (OAuth **client secrets** and **API keys**) **encrypted**, so they never sit in
-Redis as plaintext. Set `secretEncryptionKey`; the gateway decrypts on read.
+For hybrid (on-prem) deployments, set `secretEncryptionKey` to enable end-to-end
+encryption of integration secrets (OAuth **client secrets** and **API keys**). When
+configured, the Frontegg control plane delivers them **encrypted** and the gateway
+decrypts on read, in memory — they are never written to your Redis cache in cleartext.
 
 - Algorithm: **AES-256-GCM**, format `v2:<iv_hex>:<authTag_hex>:<ciphertext_hex>`.
 - The key must be a **32-character string** (used verbatim as the AES-256 key — **not** a Base64/hex-encoded 32-byte value, which would be longer and fail with `Invalid key length`) and **identical** to the one the control plane encrypts with.
 - Values without the `v2:` prefix are passed through unchanged, so it can be rolled out gradually.
 
-Source the key from a k8s Secret rather than committing it to `values.yaml`.
+To keep the key out of Helm values, provide it as `SECRET_ENCRYPTION_KEY` in an
+`existingSecret` (see [Referencing an existing Secret](#referencing-an-existing-secret))
+instead of setting `secretEncryptionKey` inline.
 
 ### Common values
 

--- a/charts/mcp-gateway/README.md
+++ b/charts/mcp-gateway/README.md
@@ -149,9 +149,15 @@ envFrom:
 ```
 
 The chart does not create or manage this Secret — it must exist in the release
-namespace before the pods start, or they fail with `CreateContainerConfigError`. Keys
-present in both `existingSecret` and `env` resolve to the `env` value (inline `value:`
-wins over `envFrom`). Changing the Secret does **not** restart the pods automatically —
+namespace before the pods start, or they fail with `CreateContainerConfigError`.
+
+Only **non-empty** `env` values are rendered inline; an empty/unset `env` key (like the
+default `redisPassword: ""`) is omitted entirely, so the same key from `existingSecret`
+takes effect. If you set a key to a non-empty value under `env` **and** in the Secret,
+the inline `env` value wins (a container `env.value` overrides `envFrom`) — so to source
+a value from the Secret, leave its `env` key empty or unset.
+
+Changing the Secret does **not** restart the pods automatically —
 run `kubectl rollout restart deploy/<release>-mcp-gateway-auth deploy/<release>-mcp-gateway-gw`
 (or use a controller like Stakater Reloader).
 

--- a/charts/mcp-gateway/templates/NOTES.txt
+++ b/charts/mcp-gateway/templates/NOTES.txt
@@ -61,6 +61,14 @@ Event delivery:
   newline-delimited JSON tagged {"stream":"mcp-gw-events",...}. Point your log
   collector (OTEL/Fluent Bit/Vector) at container stdout and filter on that stream.
 {{- end }}
+{{- with .Values.existingSecret }}
+
+External secret:
+  Loading env vars from the pre-existing Secret "{{ . }}" via envFrom. Ensure it exists
+  in namespace {{ $.Release.Namespace }} with UPPER_SNAKE_CASE keys before the pods start.
+  Changes to that Secret do not restart pods automatically — run:
+    kubectl rollout restart deploy/{{ include "fullname" $ }}-auth deploy/{{ include "fullname" $ }}-gw --namespace {{ $.Release.Namespace }}
+{{- end }}
 {{- if .Values.env.secretEncryptionKey }}
 
 Integration secret encryption:

--- a/charts/mcp-gateway/templates/_helpers.tpl
+++ b/charts/mcp-gateway/templates/_helpers.tpl
@@ -69,3 +69,15 @@ Convert camelCase to UPPER_SNAKE_CASE
 {{- $result := regexReplaceAll "([a-z0-9])([A-Z])" . "${1}_${2}" -}}
 {{- $result | upper -}}
 {{- end }}
+
+{{/*
+envFrom block loading a pre-existing Secret (.Values.existingSecret) into the
+container. Renders nothing when unset.
+*/}}
+{{- define "secretEnvFrom" -}}
+{{- with .Values.existingSecret -}}
+envFrom:
+  - secretRef:
+      name: {{ . }}
+{{- end -}}
+{{- end -}}

--- a/charts/mcp-gateway/templates/deployment-mcp-auth.yaml
+++ b/charts/mcp-gateway/templates/deployment-mcp-auth.yaml
@@ -48,8 +48,10 @@ spec:
             - name: PORT
               value: "8080"
             {{- range $key, $value := .Values.env }}
+            {{- if not (empty $value) }}
             - name: {{ include "toEnvVarName" $key }}
               value: {{ $value | quote }}
+            {{- end }}
             {{- end }}
           {{- with (include "secretEnvFrom" .) }}
           {{- . | nindent 10 }}

--- a/charts/mcp-gateway/templates/deployment-mcp-auth.yaml
+++ b/charts/mcp-gateway/templates/deployment-mcp-auth.yaml
@@ -48,7 +48,7 @@ spec:
             - name: PORT
               value: "8080"
             {{- range $key, $value := .Values.env }}
-            {{- if not (empty $value) }}
+            {{- if ne (toString $value) "" }}
             - name: {{ include "toEnvVarName" $key }}
               value: {{ $value | quote }}
             {{- end }}

--- a/charts/mcp-gateway/templates/deployment-mcp-auth.yaml
+++ b/charts/mcp-gateway/templates/deployment-mcp-auth.yaml
@@ -51,6 +51,9 @@ spec:
             - name: {{ include "toEnvVarName" $key }}
               value: {{ $value | quote }}
             {{- end }}
+          {{- with (include "secretEnvFrom" .) }}
+          {{- . | nindent 10 }}
+          {{- end }}
           ports:
             - name: http
               containerPort: 8080

--- a/charts/mcp-gateway/templates/deployment-mcp-gw.yaml
+++ b/charts/mcp-gateway/templates/deployment-mcp-gw.yaml
@@ -48,8 +48,10 @@ spec:
             - name: PORT
               value: "8080"
             {{- range $key, $value := .Values.env }}
+            {{- if not (empty $value) }}
             - name: {{ include "toEnvVarName" $key }}
               value: {{ $value | quote }}
+            {{- end }}
             {{- end }}
           {{- with (include "secretEnvFrom" .) }}
           {{- . | nindent 10 }}

--- a/charts/mcp-gateway/templates/deployment-mcp-gw.yaml
+++ b/charts/mcp-gateway/templates/deployment-mcp-gw.yaml
@@ -48,7 +48,7 @@ spec:
             - name: PORT
               value: "8080"
             {{- range $key, $value := .Values.env }}
-            {{- if not (empty $value) }}
+            {{- if ne (toString $value) "" }}
             - name: {{ include "toEnvVarName" $key }}
               value: {{ $value | quote }}
             {{- end }}

--- a/charts/mcp-gateway/templates/deployment-mcp-gw.yaml
+++ b/charts/mcp-gateway/templates/deployment-mcp-gw.yaml
@@ -51,6 +51,9 @@ spec:
             - name: {{ include "toEnvVarName" $key }}
               value: {{ $value | quote }}
             {{- end }}
+          {{- with (include "secretEnvFrom" .) }}
+          {{- . | nindent 10 }}
+          {{- end }}
           ports:
             - name: http
               containerPort: 8080

--- a/charts/mcp-gateway/values.yaml
+++ b/charts/mcp-gateway/values.yaml
@@ -146,3 +146,9 @@ env:
   # eventWebhookProvider: ""
   # eventWebhookUrl: ""
   # eventWebhookSecret: ""
+
+# Name of a pre-existing Secret (managed outside this chart, e.g. by External Secrets
+# Operator or sealed-secrets) to load into both deployments via envFrom. Its keys must
+# already be UPPER_SNAKE_CASE env var names. Use this to keep sensitive values out of
+# Helm values / env above.
+existingSecret: ""

--- a/charts/mcp-gateway/values.yaml
+++ b/charts/mcp-gateway/values.yaml
@@ -147,8 +147,4 @@ env:
   # eventWebhookUrl: ""
   # eventWebhookSecret: ""
 
-# Name of a pre-existing Secret (managed outside this chart, e.g. by External Secrets
-# Operator or sealed-secrets) to load into both deployments via envFrom. Its keys must
-# already be UPPER_SNAKE_CASE env var names. Use this to keep sensitive values out of
-# Helm values / env above.
 existingSecret: ""


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes how env vars are injected at deploy time; misconfigured or missing Secrets will prevent pods from starting, and precedence between inline env and secrets must be understood for production upgrades.
> 
> **Overview**
> **Chart 0.11.0** adds optional **`existingSecret`** so `mcp-auth` and `mcp-gw` can load sensitive env vars from a Kubernetes Secret you manage outside Helm (`envFrom` / `secretRef`), instead of only inline `env` values.
> 
> Deployments now **skip empty `env` entries**, so keys like `redisPassword: ""` are not rendered and the same name from the external Secret can apply; non-empty inline `env` still overrides `envFrom`. Post-install **NOTES** and the **README** document precedence, rollout restart after Secret changes, and tying `SECRET_ENCRYPTION_KEY` to `existingSecret`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e975d61ef8298bacb4bb8e7f736c32ab73b7735d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->