### PR TITLE
FR-26364: support configurable web deployment strategy

### DIFF
--- a/.github/workflows/unified-chart-template-check.yaml
+++ b/.github/workflows/unified-chart-template-check.yaml
@@ -23,3 +23,4 @@ jobs:
         run: |
           cd common/unified-chart
           helm template . --name-template=$NAME_TEMPLATE  --set name=$NAME --set team=$TEAM --set appVersion=$APP_VERSION --values $TEST_FILE --debug
+          bash tests/web-deployment-strategy.sh

--- a/common/unified-chart/Chart.yaml
+++ b/common/unified-chart/Chart.yaml
@@ -4,7 +4,7 @@ description: Frontegg Unified Chart
 type: application
 
 #This is a test version do not use
-version: 4.0.137
+version: 4.0.138
 
 maintainers:
   - name: "platform"

--- a/common/unified-chart/templates/web/web-deployment.yaml
+++ b/common/unified-chart/templates/web/web-deployment.yaml
@@ -10,6 +10,10 @@ metadata:
     {{- include "web.labels" $top | nindent 4 }}
 spec:
   revisionHistoryLimit: {{ $values.revisionHistoryLimit | default 2 }}
+  {{- with $values.web.strategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- if $values.argoRollouts.enabled }}
   replicas: 0
   {{- else if not $values.web.autoscaling.enabled }}

--- a/common/unified-chart/tests/web-deployment-strategy.sh
+++ b/common/unified-chart/tests/web-deployment-strategy.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+chart_dir=$(cd "$(dirname "$0")/.." && pwd)
+rendered=$(helm template strategy-test "$chart_dir" \
+  --values "$chart_dir/tests/web-deployment-strategy.values.yaml")
+
+grep -q '^  strategy:$' <<<"$rendered"
+grep -q '^    type: Recreate$' <<<"$rendered"

--- a/common/unified-chart/tests/web-deployment-strategy.values.yaml
+++ b/common/unified-chart/tests/web-deployment-strategy.values.yaml
@@ -1,0 +1,27 @@
+name: messagepit
+team: identity
+envID: test
+appVersion: "1.3.0"
+
+image:
+  repository: example.com/messagepit
+  prefix: ""
+
+argoRollouts:
+  enabled: false
+
+web:
+  enabled: true
+  strategy:
+    type: Recreate
+  service:
+    ports:
+      - name: http
+        port: 8025
+        targetPort: http
+  resources:
+    requests:
+      cpu: 50m
+      memory: 64Mi
+    limits:
+      memory: 256Mi

--- a/common/unified-chart/values.yaml
+++ b/common/unified-chart/values.yaml
@@ -109,6 +109,7 @@ web:
   command: ["/bin/bash"]
   args: ["entrypoint.sh", "service"]
   replicaCount: 1
+  strategy: {}
   podAnnotations: {}
   ports:
     - name: http


### PR DESCRIPTION
## Summary

- add optional `web.strategy` support to the unified Deployment template
- keep the default empty so existing services retain Kubernetes RollingUpdate behavior
- release unified chart version `4.0.138`
- add a render regression test for `type: Recreate`

## Why

MessagePit stores captured messages in pod-local state. Its single replica must use `Recreate` so a rollout cannot temporarily run two independent inboxes behind one Service.

## Verification

- `bash common/unified-chart/tests/web-deployment-strategy.sh`
- `helm lint common/unified-chart`
- rendered `common/unified-chart/test.values.yaml` successfully
- `git diff --check`