### PR TITLE
FR-26617: optional ingress for the MCP gateway chart

### DIFF
--- a/charts/mcp-gateway/Chart.yaml
+++ b/charts/mcp-gateway/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: mcp-gateway
 description: A Helm chart for frontegg's MCP Gateway (mcp-auth + mcp-gw)
 type: application
-version: 0.11.0
+version: 0.12.0

--- a/charts/mcp-gateway/templates/ingress.yaml
+++ b/charts/mcp-gateway/templates/ingress.yaml
@@ -32,6 +32,15 @@ spec:
                 port:
                   number: {{ $.Values.mcpAuth.port }}
           {{- end }}
+          {{- with .Values.ingress.ctxAuthRegex }}
+          - path: {{ . }}
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: {{ include "fullname" $ }}-auth
+                port:
+                  number: {{ $.Values.mcpAuth.port }}
+          {{- end }}
           - path: /
             pathType: Prefix
             backend:

--- a/charts/mcp-gateway/templates/ingress.yaml
+++ b/charts/mcp-gateway/templates/ingress.yaml
@@ -1,0 +1,42 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "fullname" . }}
+  labels:
+    {{- include "commonLabels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- with .Values.ingress.tlsSecretName }}
+  tls:
+    - hosts:
+        - {{ $.Values.ingress.host | quote }}
+      secretName: {{ . }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.ingress.host | quote }}
+      http:
+        paths:
+          {{- range .Values.ingress.authPaths }}
+          - path: {{ . }}
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "fullname" $ }}-auth
+                port:
+                  number: {{ $.Values.mcpAuth.port }}
+          {{- end }}
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "fullname" . }}-gw
+                port:
+                  number: {{ .Values.mcpGw.port }}
+{{- end }}

--- a/charts/mcp-gateway/values.yaml
+++ b/charts/mcp-gateway/values.yaml
@@ -75,7 +75,15 @@ ingress:
   className: nginx
   host: ""
   tlsSecretName: ""
-  annotations: {}
+  # MCP sessions are long-lived streams; nginx defaults sever them at 60s and buffer responses.
+  annotations:
+    nginx.ingress.kubernetes.io/use-regex: "true"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+    nginx.ingress.kubernetes.io/proxy-buffering: "off"
+  # Context can also arrive as a path prefix (/ctx/<b64>/authorize); prefix rules cannot see past
+  # it, so this regex sends the prefix form of the auth endpoints to mcp-auth as well.
+  ctxAuthRegex: '/ctx/[^/]+/(authorize|token|dcr/register|\.well-known|integration-callback|security-stepup-verify|external-mcp)'
   authPaths:
     - /authorize
     - /token

--- a/charts/mcp-gateway/values.yaml
+++ b/charts/mcp-gateway/values.yaml
@@ -68,6 +68,24 @@ mcpGw:
     failureThreshold: 10
     periodSeconds: 10
 
+# Routes the OAuth and discovery endpoints to mcp-auth and everything else to mcp-gw.
+# Disabled by default: hybrid installs front the services with their own ingress.
+ingress:
+  enabled: false
+  className: nginx
+  host: ""
+  tlsSecretName: ""
+  annotations: {}
+  authPaths:
+    - /authorize
+    - /token
+    - /dcr/register
+    - /.well-known/oauth-protected-resource
+    - /.well-known/oauth-authorization-server
+    - /integration-callback
+    - /security-stepup-verify
+    - /external-mcp
+
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
Adds an optional `Ingress` to `charts/mcp-gateway` and bumps the chart to 0.12.0.

The chart deploys `mcp-gw` and `mcp-auth` but exposes neither, because hybrid installs front them with their own ingress. A Kubernetes environment that wants the gateway reachable therefore has to hand-write one — which is what blocks running Frontegg's AI agent E2E specs against a venv.

**Routing** mirrors the Lambda `HttpApi` split, on a single host: the OAuth and discovery paths go to `mcp-auth`, everything else to `mcp-gw`.

`authPaths` defaults to the routes `apps/mcp-auth/src/router.ts` registers: `/authorize`, `/token`, `/dcr/register`, `/.well-known/oauth-protected-resource`, `/.well-known/oauth-authorization-server`, `/integration-callback`, `/security-stepup-verify`, `/external-mcp`.

**Off by default** — `ingress.enabled: false`, so existing hybrid installs render exactly as before. Consumers opt in with `host`, `className` and `tlsSecretName`.

First consumer is frontegg/venv#118, which enables it on `*.mcp-gw.<sub>.venv.life`.

Rendered and YAML-validated locally against those values; not yet applied to a cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)